### PR TITLE
Fix breaking API

### DIFF
--- a/covid-india.1h.js
+++ b/covid-india.1h.js
@@ -9,7 +9,7 @@
 //<bitbar.image>https://i.imgur.com/Ch9HY6G.png</bitbar.image>
 //<bitbar.abouturl>https://github.com/thelittlewonder/covid-19indiatracker/readme.md</bitbar.abouturl>
 
-const apiURL = 'https://exec.clay.run/kunksed/mohfw-covid';
+const apiURL = 'https://api.rootnet.in/covid19-in/stats/latest';
 const https = require('https');
 https.get(apiURL, res => {
     let data = "";
@@ -19,14 +19,14 @@ https.get(apiURL, res => {
     res.on("end", () => {
       let apiData = JSON.parse(data);
       let icon = 'iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAAEhyb7BAAAAAXNSR0IArs4c6QAAAdlJREFUOBGFkzFLHFEQgFeFeBowalAJnB4kIFpIuN+QcEmRziJ10mhpGkGwtEkgfQqv8RdYCkqKgHiNZcQmVa46MCoREaIx3/d8b9nDjQ58O/PmzZudfTObZTfySNUDGp+gAkE2kqFu9PG4ho6xz+BcI4k7U/BARwOq8BnceAJdUiuullkYlY1E4yw59P6G1xCOPMZoQak8xGuKv+DJTfBAEDeVY3BzAUx9CXlGT1qNm6kI3+2BIBZhWh1/otbW/x5KZRhvs3QnOivoCzCTJQTpTUbUH9D9MAhfIQ/EzpZgDn7ARzCT3VGHVy9i7EWHzqfRfht1HZ2NxsU4ej3a81G/QwdZ4WmGL3AAY3AEv2AWgpzyNKhIm/XLsFt4GGjG57AKtwLw3Sl+2DZY+y6YzOE0cd587P+KV/cTirdzxbpYui03YQ1KZQiv978GHvwG3uIheFGTkBJaoT9ILrbfCtwwgU1MwQamVnzHnijseWdBHDDvIM1QqsBJMIHN3gf9HbBlW3HdQnvxbyCMipdooHcwAH5CqiYlcCimwb7ra8MJvIBc7IJDasAOVMGZ9BMcu1SB+w6Pf2ZXAtZBUhvtQkrooYSf4HhawQzcK7UY8QrdjHYdHe4grkvVP0xXjBIOIZS9AAAAAElFTkSuQmCC';
-      console.log(`${apiData.countryData.total} | templateImage=${icon}`);
+      console.log(`${apiData.data.summary.total} | templateImage=${icon}`);
       console.log('---')
-      console.log("Cases:", apiData.countryData.total);
-      console.log("Recovered:", apiData.countryData.cured_dischargedTotal);
-      console.log("Deaths:", apiData.countryData.deathsTotal);
+      console.log("Cases:", apiData.data.summary.total);
+      console.log("Recovered:", apiData.data.summary.discharged);
+      console.log("Deaths:", apiData.data.summary.deaths);
       console.log("---");
       console.log("Official Helpline | href=https://covidindia.org/resources/");
-      console.log("Source | href=https://www.mohfw.gov.in/")
+      console.log("Source | href=https://www.covid19india.org/")
     });
   })
   .on("error", err => {


### PR DESCRIPTION
The current API endpoint ([https://exec.clay.run/kunksed/mohfw-covid](https://exec.clay.run/kunksed/mohfw-covid)) is not working anymore.

This PR proposes to move to a more reliable endpoint ([https://api.rootnet.in/covid19-in/stats/latest](https://api.rootnet.in/covid19-in/stats/latest)). More reliable because:

- Hosted on Cloudflare Workers without any limits thanks to the Cloudflare team (ref: [https://twitter.com/amodm/status/1239399201315753985](https://twitter.com/amodm/status/1239399201315753985))
- Suggested by the old API's author @kunksed as well (ref: [https://twitter.com/kunksed/status/1239539642837479425](https://twitter.com/kunksed/status/1239539642837479425))